### PR TITLE
Card image height bugfix

### DIFF
--- a/src/components/home/recipes/Card.module.sass
+++ b/src/components/home/recipes/Card.module.sass
@@ -66,7 +66,7 @@ $svg-adjustment: -0.5rem
 @media all and (min-width: #{ List.$medium-width })
   .card.details
     grid-column: span 2
-  .card.details .imgContainer.hasImage
+  .card.details .imgContainer img
     height: 32rem
 @media all and (min-width: #{ List.$large-width })
   .card.details


### PR DESCRIPTION
CSS was inconsistent about how to specify image height. Fixed by having
both specify height on img tags descendent from .imgContainer